### PR TITLE
Fixed multiple key type issue in AndroidKeyStore

### DIFF
--- a/eosioandroidkeystoresignatureprovider/build.gradle
+++ b/eosioandroidkeystoresignatureprovider/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosioandroidkeystoresignatureprovider'
-def libraryVersion = '0.1.0'
+def libraryVersion = '0.1.1'
 
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'

--- a/eosioandroidkeystoresignatureprovider/src/main/java/one/block/eosiojavaandroidkeystoresignatureprovider/EosioAndroidKeyStoreUtility.kt
+++ b/eosioandroidkeystoresignatureprovider/src/main/java/one/block/eosiojavaandroidkeystoresignatureprovider/EosioAndroidKeyStoreUtility.kt
@@ -137,17 +137,19 @@ class EosioAndroidKeyStoreUtility {
             val aliases = keyStore.aliases()
 
             for (alias in aliases) {
-                val keyEntry = keyStore.getEntry(alias, password) as KeyStore.PrivateKeyEntry
-                val ecPublicKey = KeyFactory.getInstance(keyEntry.certificate.publicKey.algorithm).generatePublic(
-                    X509EncodedKeySpec(keyEntry.certificate.publicKey.encoded)
-                ) as ECPublicKey
+                val keyEntry = keyStore.getEntry(alias, password)
+                if (keyEntry is KeyStore.PrivateKeyEntry) {
+                    val ecPublicKey = KeyFactory.getInstance(keyEntry.certificate.publicKey.algorithm).generatePublic(
+                        X509EncodedKeySpec(keyEntry.certificate.publicKey.encoded)
+                    ) as ECPublicKey
 
-                aliasKeyPair.add(
-                    Pair(
-                        alias,
-                        this.convertAndroidKeyStorePublicKeyToEOSFormat(androidECPublicKey = ecPublicKey)
+                    aliasKeyPair.add(
+                        Pair(
+                            alias,
+                            this.convertAndroidKeyStorePublicKeyToEOSFormat(androidECPublicKey = ecPublicKey)
+                        )
                     )
-                )
+                }
             }
 
             return aliasKeyPair


### PR DESCRIPTION
Issue: When multiple type of secret key different than PrivateKeyEntry, the method getAllAndroidKeyStoreKeysInEOSFormat will throw cast exception. More detail in the testGetAvailableKeysWithPrivateKeyEntryOnly instrumentation test. 