### PR TITLE
1.0.0 Release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ This provider is intended to be used in conjunction with [EOSIO SDK for Java](ht
 To use Android Keystore Signature Provider with EOSIO SDK for Java in your app, add the following modules to your `build.gradle`:
 
 ```java
-implementation 'one.block:eosiojava:0.1.2'
-implementation 'one.block:eosioandroidkeystoresignatureprovider:0.1.1'
+implementation 'one.block:eosiojava:1.0.0'
+implementation 'one.block:eosioandroidkeystoresignatureprovider:1.0.0'
 ```
 
 If you are using Android Keytore Signature Provider, or any library that depends on it, in an Android application you must also add the following to your application's `build.gradle` file in the `android` section:
@@ -151,6 +151,10 @@ Delete all keys in the Keystore by calling:
 * `EosioAndroidKeyStoreUtility.deleteAllKeys(loadStoreParameter: KeyStore.LoadStoreParameter?)`
 
 ## Releases
+
+11/05/2020
+
+Version 1.0.0 This version consumes the new eosio-java library version 1.0.0.
 
 2/27/20
 

--- a/eosioandroidkeystoresignatureprovider/build.gradle
+++ b/eosioandroidkeystoresignatureprovider/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.0.2'
 
-    implementation 'one.block:eosiojava:0.1.2'
+    implementation 'one.block:eosiojava:1.0.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
@@ -53,7 +53,7 @@ dependencies {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosioandroidkeystoresignatureprovider'
-def libraryVersion = '0.1.1'
+def libraryVersion = '1.0.0'
 
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'

--- a/eosioandroidkeystoresignatureprovider/src/androidTest/java/one/block/eosiojavaandroidkeystoresignatureprovider/EosioAndroidKeyStoreSignatureProviderInstrumentedTest.kt
+++ b/eosioandroidkeystoresignatureprovider/src/androidTest/java/one/block/eosiojavaandroidkeystoresignatureprovider/EosioAndroidKeyStoreSignatureProviderInstrumentedTest.kt
@@ -206,7 +206,7 @@ class EosioAndroidKeyStoreSignatureProviderInstrumentedTest {
             eosioAndroidKeyStoreSignatureProvider.signTransaction(transactionSignatureRequest)
 
         Assert.assertNull(transactionSignatureResponse.error)
-        Assert.assertEquals(TEST_CONST_SERIALIZED_TRANSACTION, transactionSignatureResponse.serializeTransaction)
+        Assert.assertEquals(TEST_CONST_SERIALIZED_TRANSACTION, transactionSignatureResponse.serializedTransaction)
         Assert.assertEquals(1, transactionSignatureResponse.signatures.size)
         Assert.assertNotEquals("", transactionSignatureResponse.signatures[0])
         Assert.assertTrue(transactionSignatureResponse.signatures[0].contains("SIG_R1_", true))
@@ -262,7 +262,7 @@ class EosioAndroidKeyStoreSignatureProviderInstrumentedTest {
             eosioAndroidKeyStoreSignatureProvider.signTransaction(transactionSignatureRequest)
 
         Assert.assertNull(transactionSignatureResponse.error)
-        Assert.assertEquals(TEST_CONST_SERIALIZED_TRANSACTION, transactionSignatureResponse.serializeTransaction)
+        Assert.assertEquals(TEST_CONST_SERIALIZED_TRANSACTION, transactionSignatureResponse.serializedTransaction)
         Assert.assertEquals(
             TEST_CONST_GET_AVAILABLE_KEY_MULTIPLE_KEY_AMOUNT,
             transactionSignatureResponse.signatures.size


### PR DESCRIPTION
Update library version id and dependencies to 1.0.0.
Fix some outdate method references in unit tests.
Update README with new version numbers in the basic usage section.